### PR TITLE
indexで一覧を降順にソート、作成日時の表示を追加、テストの追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %w(show edit update destroy)
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: "DESC")
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,11 +3,13 @@
   <tr>
   <th>タイトル</th>
   <th>内容</th>
+  <th>作成日時</th>
   </tr>
   <% @tasks.each do |task| %>
     <tr>
       <td><%= task.title %></td>
       <td><%= task.content %></td>
+      <td><%= task.created_at %></td>
       <td><%= link_to '詳細', task_path(task) %></td>
       <td><%= link_to '編集', edit_task_path(task) %></td>
       <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか?' } %></td>

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,17 @@
+# 「FactoryBotを使用します」という記述
+FactoryBot.define do
+
+  # 作成するテストデータの名前を「task」とします
+  # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
+  factory :task do
+    title { 'Factoryで作ったデフォルトのタイトル１' }
+    content { 'Factoryで作ったデフォルトのコンテント１' }
+  end
+
+  # 作成するテストデータの名前を「second_task」とします
+  # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
+  factory :second_task, class: Task do
+    title { 'Factoryで作ったデフォルトのタイトル２' }
+    content { 'Factoryで作ったデフォルトのコンテント２' }
+  end
+end

--- a/spec/features/task_everyleaf.spec.rb
+++ b/spec/features/task_everyleaf.spec.rb
@@ -3,13 +3,15 @@ require 'rails_helper'
 
 # このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
 RSpec.feature "タスク管理機能", type: :feature do
+  background do
+    FactoryBot.create(:task)
+    FactoryBot.create(:second_task)
+  end
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
   scenario "タスク一覧のテスト" do
-    Task.create!(title: 'test1', content: 'foo')
-    Task.create!(title: 'test2', content: 'bar')
     visit tasks_path
-    expect(page).to have_content 'foo'
-    expect(page).to have_content 'bar'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル１'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル２'
   end
 
   scenario "タスク作成のテスト" do
@@ -23,10 +25,19 @@ RSpec.feature "タスク管理機能", type: :feature do
   end
 
   scenario "タスク詳細のテスト" do
-    Task.create!(title: 'hello', content: 'world')
     visit tasks_path
-    click_on '詳細'
-    expect(page).to have_content 'hello'
-    expect(page).to have_content 'world'
+    click_on '詳細', match: :first
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル２'
+    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント２'
   end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    Task.create!(title: '最新のタイトル', content: '最新のコンテント')
+    visit tasks_path
+    save_and_open_page
+    click_on '詳細', match: :first
+    expect(page).to have_content '最新のタイトル'
+    expect(page).to have_content '最新のコンテント'
+  end
+  
 end


### PR DESCRIPTION
indexでの降順ソートテストの考え方ですが
バックグラウンドで作ったデータの後に、ソート確認シナリオ内で新たにタスクのテストレコードを
作成して、indexで詳細リンクをmatch: :firstでクリックして飛んで、その先に表示されている内容が
シナリオ内でバックグラウンド後に作成したレコードのタイトルとコンテントならば降順ソートが
成功しているという考え方でテストを書きましたが合っていますでしょうか