### PR TITLE
ステップ15の完了

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'spring-commands-rspec'
   gem 'launchy'
-  gem 'pry-rails'
   gem 'pry-byebug'
 end
 
@@ -32,12 +31,14 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry-rails'
 end
 
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
+  gem 'pry-rails'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'spring-commands-rspec'
   gem 'launchy'
+  gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -116,6 +117,14 @@ GEM
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -233,6 +242,8 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   pg
+  pry-byebug
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.2, >= 5.2.2.1)
   rspec-rails

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,22 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %w(show edit update destroy)
   def index
-    if params[:sort_flag]
-      @tasks = Task.all.order(deadline: "DESC")
+    if params[:search_flag]
+      if params[:search_title] && params[:search_status]
+        @tasks = Task.where('status LIKE ?', "%#{params[:search_status]}%").where('title LIKE ?', "%#{params[:search_title]}%")
+      elsif params[:search_title] == "" && params[:search_status]
+        @tasks = Task.where('status LIKE ?', "%#{params[:search_status]}%")
+      elsif params[:search_title] && params[:search_status] == ""
+        @tasks = Task.where('title LIKE ?', "%#{params[:search_title]}%")
+      elsif params[:search_title] == "" && params[:search_status] == ""
+        @tasks = Task.all.order(created_at: "DESC")
+      end
     else
-      @tasks = Task.all.order(created_at: "DESC")
+      if params[:sort_flag]
+        @tasks = Task.all.order(deadline: "DESC")
+      else
+        @tasks = Task.all.order(created_at: "DESC")
+      end
     end
   end
 
@@ -45,7 +57,7 @@ class TasksController < ApplicationController
 
 
   def task_params
-    params.require(:task).permit(:title, :content, :deadline)
+    params.require(:task).permit(:title, :content, :deadline, :status)
   end
   
   def set_task

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,22 +1,24 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %w(show edit update destroy)
   def index
-    if params[:search_flag] == "true"     # 検索フォームからの処理
-      binding.pry
-      if params[:search_title] && params[:search_status]    # 入力欄どちらもあり
-        @tasks = Task.where('status LIKE ?', "%#{params[:search_status]}%").where('title LIKE ?', "%#{params[:search_title]}%")
-      elsif params[:search_title].blank? && params[:search_status]     # タイトルのみ空
-        @tasks = Task.where('status LIKE ?', "%#{params[:search_status]}%")
-      elsif params[:search_title] && params[:search_status].blank?       # ステータスのみ空
-        @tasks = Task.where('title LIKE ?', "%#{params[:search_title]}%")
-      elsif params[:search_title].blank? && params[:search_status].blank?  # ステータスもタイトルも空
-        @tasks = Task.all.order(created_at: "DESC")
+    title = params[:search_title] if params[:search_title].present?
+    status = params[:search_status] if params[:search_status].present?
+
+    if params[:search_flag] == "true"     # 検索フォームからの処理か分岐
+      if params[:search_title].present? && params[:search_status].present?    # 入力欄どちらもあり
+        @tasks = Task.status_title_like_where(status, title)
+      elsif params[:search_title].empty? && params[:search_status].present?     # タイトルのみ空
+        @tasks = Task.status_like_where(status)
+      elsif params[:search_title].present? && params[:search_status].empty?      # ステータスのみ空
+        @tasks = Task.title_like_where(title)
+      elsif params[:search_title].empty? && params[:search_status].empty?  # ステータスもタイトルも空
+        @tasks = Task.created_at_desc
       end
     else     # 検索フォームから以外の処理
       if params[:sort_flag]       #ソートリンク(終了期限でソート)からの処理
-        @tasks = Task.all.order(deadline: "ASC")
+        @tasks = Task.deadline_asc
       else                        #ソートリンク(タスク追加が新しい順にソート)からの処理
-        @tasks = Task.all.order(created_at: "DESC")
+        @tasks = Task.created_at_desc
       end
     end
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,20 +1,21 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %w(show edit update destroy)
   def index
-    if params[:search_flag]
-      if params[:search_title] && params[:search_status]
+    if params[:search_flag] == "true"     # 検索フォームからの処理
+      binding.pry
+      if params[:search_title] && params[:search_status]    # 入力欄どちらもあり
         @tasks = Task.where('status LIKE ?', "%#{params[:search_status]}%").where('title LIKE ?', "%#{params[:search_title]}%")
-      elsif params[:search_title] == "" && params[:search_status]
+      elsif params[:search_title].blank? && params[:search_status]     # タイトルのみ空
         @tasks = Task.where('status LIKE ?', "%#{params[:search_status]}%")
-      elsif params[:search_title] && params[:search_status] == ""
+      elsif params[:search_title] && params[:search_status].blank?       # ステータスのみ空
         @tasks = Task.where('title LIKE ?', "%#{params[:search_title]}%")
-      elsif params[:search_title] == "" && params[:search_status] == ""
+      elsif params[:search_title].blank? && params[:search_status].blank?  # ステータスもタイトルも空
         @tasks = Task.all.order(created_at: "DESC")
       end
-    else
-      if params[:sort_flag]
-        @tasks = Task.all.order(deadline: "DESC")
-      else
+    else     # 検索フォームから以外の処理
+      if params[:sort_flag]       #ソートリンク(終了期限でソート)からの処理
+        @tasks = Task.all.order(deadline: "ASC")
+      else                        #ソートリンク(タスク追加が新しい順にソート)からの処理
         @tasks = Task.all.order(created_at: "DESC")
       end
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,4 +3,10 @@ class Task < ApplicationRecord
   validates :content, presence: true, length: { maximum: 300 }
   validates :deadline, presence: true
   validates :status, presence: true
+  #scope定義
+  scope :status_title_like_where, -> (params1, params2){where('status LIKE ?', "%#{params1}%").where('title LIKE ?', "%#{params2}%")}
+  scope :status_like_where, -> (params){where('status LIKE ?', "%#{params}%")}
+  scope :title_like_where, -> (params){where('title LIKE ?', "%#{params}%")}
+  scope :deadline_asc, -> {all.order(deadline: "ASC")}
+  scope :created_at_desc, -> {all.order(created_at: "DESC")}
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,5 @@ class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 80 }
   validates :content, presence: true, length: { maximum: 300 }
   validates :deadline, presence: true
+  validates :status, presence: true
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -20,6 +20,10 @@
     <%= f.date_select :deadline, id: 'deadline' %>
   </div>
   <div>
+    <%= f.label :status %>
+    <%= f.select :status, ["未着手", "着手中", "完了"]%>
+  </div>
+  <div>
     <%= f.submit '作成' %>
   </div>
 <% end %>

--- a/app/views/tasks/_search.html.erb
+++ b/app/views/tasks/_search.html.erb
@@ -1,0 +1,9 @@
+<%= form_with local: true, url: tasks_path, method: 'get' do |f| %>
+<span><タスク検索></span>
+<%= f.label :search_status, 'ステータス' %>
+<%= f.text_field :search_status %>
+<%= f.label :search_title, 'タイトル' %>
+<%= f.text_field :search_title %>
+<%= f.hidden_field :search_flag, value: true %>
+<%= f.submit '検索' %>
+<% end %>

--- a/app/views/tasks/_search.html.erb
+++ b/app/views/tasks/_search.html.erb
@@ -1,9 +1,9 @@
 <%= form_with local: true, url: tasks_path, method: 'get' do |f| %>
 <span><タスク検索></span>
 <%= f.label :search_status, 'ステータス' %>
-<%= f.select :search_status, [nil,"未着手", "着手中", "完了"] %>
+<%= f.select :search_status, ["", "未着手", "着手中", "完了"], id: 'task_status' %>
 <%= f.label :search_title, 'タイトル' %>
-<%= f.text_field :search_title %>
+<%= f.text_field :search_title, id: 'task_title' %>
 <%= f.hidden_field :search_flag, value: true %>
 <%= f.submit '検索' %>
 <% end %>

--- a/app/views/tasks/_search.html.erb
+++ b/app/views/tasks/_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_with local: true, url: tasks_path, method: 'get' do |f| %>
 <span><タスク検索></span>
 <%= f.label :search_status, 'ステータス' %>
-<%= f.text_field :search_status %>
+<%= f.select :search_status, [nil,"未着手", "着手中", "完了"] %>
 <%= f.label :search_title, 'タイトル' %>
 <%= f.text_field :search_title %>
 <%= f.hidden_field :search_flag, value: true %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,11 +1,13 @@
 <h2><%= t('page.index') %></h2>
-<div><%= link_to '終了期限でソートする', tasks_path(sort_flag: true) %> | <%= link_to 'タスク追加が新しい順にソート', tasks_path(sort_flag: nil) %></div>
+<div><%= render 'search' %></div><br>
+<div><%= link_to '終了期限でソートする', tasks_path(sort_flag: true) %> | <%= link_to 'タスク追加が新しい順にソート', tasks_path(sort_flag: nil) %></div><br>
 <table>
   <tr>
   <th>タイトル</th>
   <th>内容</th>
   <th>作成日時</th>
   <th>終了期限</th>
+  <th>ステータス</th>
   </tr>
   <% @tasks.each do |task| %>
     <tr>
@@ -13,11 +15,12 @@
       <td><%= task.content %></td>
       <td><%= task.created_at %></td>
       <td><%= task.deadline %></td>
+      <td><%= task.status %></td>
       <td><%= link_to '詳細', task_path(task) %></td>
       <td><%= link_to '編集', edit_task_path(task) %></td>
       <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか?' } %></td>
     </tr>
   <% end %>
-</table>
+</table><br>
 
 <div><%= link_to 'タスク作成', new_task_path %></div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,4 +2,6 @@
 <div>タスクタイトル: <%= @task.title %></div>
 <div>作業内容: <%= @task.content %></div>
 <div>終了期限: <%= @task.deadline %></div>
+<div>ステータス: <%= @task.status %>
+</div>
 <div><%= link_to '編集', edit_task_path(@task) %> | <%= link_to '戻る', tasks_path %></div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
         title: タイトル名
         content: タスク詳細
         deadline: 終了期限
+        status: ステータス
   attributes:
     created_at: 作成日時
     updated_at: 更新日時

--- a/db/migrate/20190320050828_add_status_to_tasks.rb
+++ b/db/migrate/20190320050828_add_status_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStatusToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :status, :string, null: false, default: "未着手"
+  end
+end

--- a/db/migrate/20190320075015_add_index_to_task.rb
+++ b/db/migrate/20190320075015_add_index_to_task.rb
@@ -1,0 +1,6 @@
+class AddIndexToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :status
+    add_index :tasks, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_20_015052) do
+ActiveRecord::Schema.define(version: 2019_03_20_050828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_03_20_015052) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "deadline", null: false
+    t.string "status", default: "未着手", null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_20_050828) do
+ActiveRecord::Schema.define(version: 2019_03_20_075015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2019_03_20_050828) do
     t.datetime "updated_at", null: false
     t.date "deadline", null: false
     t.string "status", default: "未着手", null: false
+    t.index ["status"], name: "index_tasks_on_status"
+    t.index ["title"], name: "index_tasks_on_title"
   end
 
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -4,16 +4,32 @@ FactoryBot.define do
   # 作成するテストデータの名前を「task」とします
   # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
   factory :task do
-    title { 'Factoryで作ったデフォルトのタイトル１' }
-    content { 'Factoryで作ったデフォルトのコンテント１' }
+    title { 'Factoryで作ったデフォルトのタイトル1' }
+    content { 'Factoryで作ったデフォルトのコンテント1' }
     deadline { '2019-03-30' }
+    status { '未着手' }
   end
 
   # 作成するテストデータの名前を「second_task」とします
   # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
   factory :second_task, class: Task do
-    title { 'Factoryで作ったデフォルトのタイトル２' }
-    content { 'Factoryで作ったデフォルトのコンテント２' }
+    title { 'Factoryで作ったデフォルトのタイトル2' }
+    content { 'Factoryで作ったデフォルトのコンテント2' }
     deadline { '2019-03-25' }
+    status { '着手中' }
+  end
+
+  factory :third_task, class: Task do
+    title { 'Factoryで作ったデフォルトのタイトル3' }
+    content { 'Factoryで作ったデフォルトのコンテント3' }
+    deadline { '2019-03-26' }
+    status { '完了' }
+  end
+
+  factory :fourth_task, class: Task do
+    title { 'Factoryで作ったデフォルトのタイトル4' }
+    content { 'Factoryで作ったデフォルトのコンテント4' }
+    deadline { '2019-03-26' }
+    status { '着手中' }
   end
 end

--- a/spec/features/task_everyleaf.spec.rb
+++ b/spec/features/task_everyleaf.spec.rb
@@ -4,14 +4,16 @@ require 'date'
 # このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
 RSpec.feature "タスク管理機能", type: :feature do
   background do
-    FactoryBot.create(:task)
-    FactoryBot.create(:second_task)
+    create(:task)
+    create(:second_task)
+    create(:third_task)
+    create(:fourth_task)
   end
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
   scenario "タスク一覧のテスト" do
     visit tasks_path
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル１'
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル２'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル1'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル2'
   end
 
   scenario "タスク作成のテスト" do
@@ -19,20 +21,20 @@ RSpec.feature "タスク管理機能", type: :feature do
     visit new_task_path
     fill_in 'title', with: 'foo'
     fill_in 'content', with: 'bar'
-    select '2019', from: 'task_deadline_1i'    #daedlineカラム追加により追記
-    select '3', from: 'task_deadline_2i'       #daedlineカラム追加により追記
-    select '27', from: 'task_deadline_3i'      #daedlineカラム追加により追記
+    select '2019', from: 'task_deadline_1i'
+    select '3', from: 'task_deadline_2i'
+    select '27', from: 'task_deadline_3i'
     click_on '作成'
     expect(page).to have_content 'foo'
     expect(page).to have_content 'bar'
-    expect(page).to have_content '2019-03-27'  #daedlineカラム追加により追記
+    expect(page).to have_content '2019-03-27'
   end
 
   scenario "タスク詳細のテスト" do
     visit tasks_path
     click_on '詳細', match: :first
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル２'
-    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント２'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル4'
+    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント4'
 
   end
 
@@ -45,17 +47,89 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).to have_content '2019-03-23'
   end
 
-  scenario "終了期限でソートするを押すと最初に登録した終了期限が長いタスクが上にくる" do
+  scenario "終了期限でソートするを押すと2番目に登録した終了期限が一番近いタスク(3/25)が上にくるかのテスト" do
     #ファクトリーで3/30が最初、次に3/25日が終了期限のタスクが作成される
     #ここで3/28が期限のタスクを作ると、作成日降順なので普通は3/28のタスクが一番上になる
-    #終了期限でソートを押したら一番上に3/30のタスクが来ていればテスト成功
+    #終了期限でソートを押したら終了期限が迫っているものが一番上にソートされるので一番上が3/25のタスクが来ていればテスト成功
     Task.create(title: 'last_create_task', content: 'last_create_content', deadline: '2019-03-28')
     visit tasks_path
     click_on '終了期限でソート'
     click_on '詳細', match: :first
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル１'
-    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント１'
-    expect(page).to have_content '2019-03-30'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル2'
+    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント2'
+    expect(page).to have_content '2019-03-25'
   end
   
+end
+
+RSpec.feature "タスク検索機能", type: :feature do
+  background do
+    create(:task)
+    create(:second_task)
+    create(:third_task)
+    create(:fourth_task)
+  end
+
+  scenario "タイトルのみでの絞り込み検索テスト" do
+    #ステータスフォームは空欄、タイトルフォームはタイトル3で検索するとレコード3のみが表示される
+    visit tasks_path
+    fill_in 'task_title', with: 'タイトル3'
+    click_on '検索'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル3'
+    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント3'
+    expect(page).to have_content '2019-03-26'
+    expect(page).to have_content '完了'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル1'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル2'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル4'
+  end
+
+  scenario "ステータスのみでの絞り込み検索テスト" do
+    #ステータスフォーム未着手、タイトルフォーム空欄で検索するとレコード1のみが表示される
+    visit tasks_path
+    select "未着手", from: 'search_status'
+    click_on '検索'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル1'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル2'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル3'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル4'
+  end
+
+  scenario "ステータス、フォームでのアンド検索テスト" do
+    #ステータスフォーム着手中、タイトルフォームでタイトル2で絞り込むとレコード2のみ表示される
+    visit tasks_path
+    select "着手中", from: 'search_status'
+    fill_in 'task_title', with: 'タイトル2'
+    click_on '検索'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル2'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル1'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル3'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル4'
+  end
+
+  scenario "条件なしで検索すると作成日descで全件表示されるテスト" do
+    #ステータスフォーム空欄、タイトルフォーム空欄で絞り込むと全件表示され、一番上にレコード4がくる
+    visit tasks_path
+    click_on '検索'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル1'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル2'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル3'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル4'
+    click_on '詳細', match: :first
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル4'
+    expect(page).to have_content '着手中'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのコンテント3'
+  end
+
+  scenario "存在しないタイトルのみで検索すると何も表示されないテスト" do
+    #ステータスフォーム空欄、タイトルフォームでタイトル5で絞り込むと1つもタスクは表示されないつまりタスク1,2,3,4は表示されない
+    visit tasks_path
+    fill_in 'task_title', with: 'タイトル5'
+    click_on '検索'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル1'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル2'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル3'
+    expect(page).not_to have_content 'Factoryで作ったデフォルトのタイトル4'
+  end
+
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -53,31 +53,31 @@ RSpec.describe Task, type: :model do
 
   describe "scope" do
     before do
-      let!(:task_a) { create(:task) }
-      let!(:task_b) { create(:second_task) }
-      let!(:task_c) { create(:third_task) }
-      let!(:task_d) { create(:fourth_task) }
+      create(:task)
+      create(:second_task)
+      create(:third_task)
+      create(:fourth_task)
     end
     it "status_title_like_whereのテスト" do
-      binding.pry
-      subject { Task.status_like_where("着手中", "タイトル4") }
-      it { is_expected.to eq task_d }
+      expect(Task.status_title_like_where("着手中", "タイトル4")).to eq Task.where("status LIKE ?", "%着手中%").where("title LIKE ?", "%タイトル4%")
     end
 
-    # it "status_like_whereのテスト" do
-    # end
+    it "status_like_whereのテスト" do
+      expect(Task.status_like_where("完了")).to eq Task.where("status LIKE ?", "%完了%")
 
-    # it "title_like_whereのテスト" do
-    # end
+    end
 
-    # it "deadline_ascのテスト" do
-    # end
+    it "title_like_whereのテスト" do
+      expect(Task.title_like_where("タイトル2")).to eq Task.where("title LIKE ?", "%タイトル2%")
+    end
 
-    # it "created_at_descのテスト" do
-    # end
+    it "deadline_ascのテスト" do
+      expect(Task.deadline_asc).to eq Task.all.order(deadline: "ASC")
+    end
+
+    it "created_at_descのテスト" do
+      expect(Task.created_at_desc).to eq Task.all.order(created_at: "DESC")
+    end
 
   end
 end
-
-
-  

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,38 +2,82 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
 
-  it "titleが空ならバリデーションが通らない" do
-    task = Task.new(title: '', content: '失敗テスト')
-    expect(task).not_to be_valid
+  describe "validation" do
+    before do
+      @task = build(:task)
+    end
+    it "titleが空ならバリデーションが通らない" do
+      @task.title = ""
+      expect(@task).not_to be_valid
+    end
+
+    it "contentが空ならバリデーションが通らない" do
+      @task.content = ""
+      expect(@task).not_to be_valid
+    end
+
+    it "deadlineが空ならバリデーションが通らない" do
+      @task.deadline = ""
+      expect(@task).not_to be_valid
+    end
+
+    it "statusが空ならバリデーションが通らない" do
+      @task.status = ""
+      expect(@task).not_to be_valid
+    end
+
+    it "titleとcontentとstatusとdeadlineが記載されていればバリデーションが通る" do
+      expect(@task).to be_valid
+    end
+
+    it "titleが81文字以上だとバリデーションが通らない" do
+      @task.title = 't'*81
+      expect(@task).not_to be_valid
+    end
+
+    it "titleが80以下だとバリデーションが通る" do
+      @task.title = 't'*80
+      expect(@task).to be_valid
+    end
+
+    it "contentが301文字以上だとバリデージョンが通らない" do
+      @task.content = 't'*301
+      expect(@task).not_to be_valid
+    end
+
+    it "contentが300文字以下だとバリデーションが通る" do
+      @task.content = 't'*300
+      expect(@task).to be_valid
+    end
   end
 
-  it "contentが空ならバリデーションが通らない" do
-    task = Task.new(title:'失敗テスト', content: '')
-    expect(task).not_to be_valid
-  end
+  describe "scope" do
+    before do
+      let!(:task_a) { create(:task) }
+      let!(:task_b) { create(:second_task) }
+      let!(:task_c) { create(:third_task) }
+      let!(:task_d) { create(:fourth_task) }
+    end
+    it "status_title_like_whereのテスト" do
+      binding.pry
+      subject { Task.status_like_where("着手中", "タイトル4") }
+      it { is_expected.to eq task_d }
+    end
 
-  it "titleとcontentに内容が記載されていればバリデーションが通る" do
-    task = Task.new(title: '成功テスト', content: '成功テスト')
-    expect(task).to be_valid
-  end
+    # it "status_like_whereのテスト" do
+    # end
 
-  it "titleが81文字以上だとバリデーションが通らない" do
-    task = Task.new(title: 't'*81, content: '失敗テスト')
-    expect(task).not_to be_valid
-  end
+    # it "title_like_whereのテスト" do
+    # end
 
-  it "titleが80以下だとバリデーションが通る" do
-    task = Task.new(title: 't'*80, content: '失敗テスト')
-    expect(task).to be_valid
-  end
+    # it "deadline_ascのテスト" do
+    # end
 
-  it "contentが301文字以上だとバリデージョンが通らない" do
-    task = Task.new(title: '失敗テスト', content: 't'*301)
-    expect(task).not_to be_valid
-  end
+    # it "created_at_descのテスト" do
+    # end
 
-  it "contentが300文字以下だとバリデーションが通る" do
-    task = Task.new(title: '失敗テスト', content: 't'*300)
-    expect(task).to be_valid
   end
 end
+
+
+  

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,4 +69,6 @@ RSpec.configure do |config|
   config.after(:all) do
     DatabaseCleaner.clean
   end
+  config.include FactoryBot::Syntax::Methods
+
 end


### PR DESCRIPTION
一覧、登録、編集にステータス項目の追加
ステータスとタイトルでタスクを検索できるように
TaskコントローラーのクエリをTaskモデルに移動
スコープ追加によるTaskモデルの単体テスト追加
検索機能追加による統合テストの追加
